### PR TITLE
Point addition gadget impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+sudo: true
+os: 
+  - linux
+
+matrix:
+  fast_finish: false
+  include:
+  - rust: nightly
+
+
+before_install:
+  - sudo apt-get update
+
+# Main build
+script:
+  - cargo check
+  - cargo build --verbose --all
+  - cargo test --verbose --all
+
+
+# Send a notification to the Dusk build Status Telegram channel once the CI build completes
+after_script:
+  - bash <(curl -s https://raw.githubusercontent.com/dusk-network/tools/master/bash/telegram_ci_notifications.sh)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,13 @@ edition = "2018"
 
 [dependencies]
 zerocaf = {git = "https://github.com/dusk-network/dusk-zerocaf", branch = "master"}
+merlin = "2.0.0"
+curve25519-dalek = "2.0.0"
 
 [dependencies.bulletproofs]
 git = "https://github.com/dusk-network/bulletproofs"
 branch = "dalek-v2"
 features = ["yoloproofs"]
+
+[dev-dependencies]
+rand = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,9 @@ edition = "2018"
 zerocaf = {git = "https://github.com/dusk-network/dusk-zerocaf", branch = "master"}
 merlin = "2.0.0"
 curve25519-dalek = "2.0.0"
+rand = "0.7.3"
 
 [dependencies.bulletproofs]
 git = "https://github.com/dusk-network/bulletproofs"
 branch = "dalek-v2"
 features = ["yoloproofs"]
-
-[dev-dependencies]
-rand = "0.7.3"

--- a/src/gadgets/point_addition/add.rs
+++ b/src/gadgets/point_addition/add.rs
@@ -34,8 +34,15 @@ pub fn point_addition_gadget(
         // Try to move this to additions since they are free
         let minus_a = cs.multiply(LC::from(a), LC::from(A)).2;
         let minus_b = cs.multiply(LC::from(a), LC::from(B)).2;
-        minus_a + minus_b + E12;
+        minus_a + minus_b + E12
     };
-    //let F =
-    unimplemented!()
+    let F = D - C;
+    let G = D + C;
+    let H = B + A;
+    (
+        Variable::from(cs.multiply(E.clone(), F.clone()).2),
+        Variable::from(cs.multiply(G.clone(), H.clone()).2),
+        Variable::from(cs.multiply(F, G).2),
+        Variable::from(cs.multiply(E, H).2),
+    )
 }

--- a/src/gadgets/point_addition/add.rs
+++ b/src/gadgets/point_addition/add.rs
@@ -1,9 +1,25 @@
 use bulletproofs::r1cs::{ConstraintSystem, LinearCombination as LC, Variable};
-use zerocaf::edwards::{AffinePoint, EdwardsPoint};
-use zerocaf::field::FieldElement as Fq;
+use curve25519_dalek::scalar::Scalar;
+use zerocaf::field::FieldElement;
 use zerocaf::ristretto::RistrettoPoint;
 
-pub fn point_addition_gadget(
+pub fn fq_as_scalar(elem: FieldElement) -> Scalar {
+    Scalar::from_bytes_mod_order(elem.to_bytes())
+}
+
+pub fn commit_point_coords(
+    cs: &mut ConstraintSystem,
+    point: RistrettoPoint,
+) -> (Variable, Variable, Variable, Variable) {
+    let p_x = cs.allocate(Some(fq_as_scalar(point.0.X))).unwrap();
+    let p_y = cs.allocate(Some(fq_as_scalar(point.0.Y))).unwrap();
+    let p_z = cs.allocate(Some(fq_as_scalar(point.0.Z))).unwrap();
+    let p_t = cs.allocate(Some(fq_as_scalar(point.0.T))).unwrap();
+
+    (p_x, p_y, p_z, p_t)
+}
+
+pub fn add_point_addition_gadget(
     cs: &mut ConstraintSystem,
     (p1_x, p1_y, p1_z, p1_t): (Variable, Variable, Variable, Variable),
     (p2_x, p2_y, p2_z, p2_t): (Variable, Variable, Variable, Variable),
@@ -45,4 +61,52 @@ pub fn point_addition_gadget(
         Variable::from(cs.multiply(F, G).2),
         Variable::from(cs.multiply(E, H).2),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bulletproofs::r1cs::Prover;
+    use bulletproofs::{BulletproofGens, PedersenGens};
+    use merlin::Transcript;
+    use rand::thread_rng;
+    use zerocaf::edwards::{AffinePoint, EdwardsPoint};
+    use zerocaf::field::FieldElement as Fq;
+
+    #[test]
+    fn point_addition_gadget() {
+        let mut rng = thread_rng();
+
+        let gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"Testing");
+
+        let mut prover = Prover::new(&gens, &mut transcript);
+
+        let p1 = RistrettoPoint::new_random_point(&mut rng);
+        let p1_commits = commit_point_coords(&mut prover, p1);
+        let p2 = RistrettoPoint::new_random_point(&mut rng);
+        let p2_commits = commit_point_coords(&mut prover, p2);
+        let p_res = p1 + p2;
+        let a = zerocaf::constants::EDWARDS_A;
+        let a_comm = prover.allocate(Some(fq_as_scalar(a))).unwrap();
+        let d = zerocaf::constants::EDWARDS_D;
+        let d_comm = prover.allocate(Some(fq_as_scalar(d))).unwrap();
+
+        let (X, Y, Z, T) =
+            add_point_addition_gadget(&mut prover, p1_commits, p2_commits, d_comm, a_comm);
+        let (X_real, Y_real, Z_real, T_real) = commit_point_coords(&mut prover, p_res);
+        // As specified on the Ristretto protocol docs:
+        // https://ristretto.group/formulas/equality.html
+        // and we are on the twisted case, we compare
+        // `X1*Y2 == Y1*X2 | X1*X2 == Y1*Y2`.
+        let (_, _, x1_y2) = prover.multiply(LC::from(X), LC::from(Y_real));
+        let (_, _, y1_x2) = prover.multiply(LC::from(Y), LC::from(X_real));
+        let constraint = x1_y2 - y1_x2;
+        prover.constrain(LC::from(constraint));
+        let prove = prover.prove(&BulletproofGens::new(32, 1)).unwrap();
+        let verif = bulletproofs::r1cs::Verifier::new(&mut transcript);
+        assert!(verif
+            .verify(&prove, &gens, &BulletproofGens::new(32, 1), &mut rng)
+            .is_ok())
+    }
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,0 +1,77 @@
+use bulletproofs::r1cs::{ConstraintSystem, LinearCombination as LC, Prover, Variable};
+use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::scalar::Scalar;
+use rand::thread_rng;
+use zerocaf::field::FieldElement;
+use zerocaf::ristretto::RistrettoPoint;
+
+pub fn fq_as_scalar(elem: FieldElement) -> Scalar {
+    Scalar::from_bytes_mod_order(elem.to_bytes())
+}
+
+/// Commits the coordinates of the two public points in the CS
+pub fn commit_2_point_coords(
+    prover: &mut Prover,
+    points: (RistrettoPoint, RistrettoPoint),
+) -> (Vec<CompressedRistretto>, Vec<Variable>) {
+    let mut commitments: Vec<CompressedRistretto> = Vec::new();
+    let mut vars: Vec<Variable> = Vec::new();
+    for point in &[points.0, points.1] {
+        let com_res = prover.commit(fq_as_scalar(point.0.X), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+        let com_res = prover.commit(fq_as_scalar(point.0.Y), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+        let com_res = prover.commit(fq_as_scalar(point.0.Z), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+        let com_res = prover.commit(fq_as_scalar(point.0.T), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+    }
+    (commitments, vars)
+}
+
+/// Converts n points coordinates to variables returning them inside of a vector
+pub fn n_point_coords_to_LC(points: &[RistrettoPoint]) -> Vec<(LC, LC, LC, LC)> {
+    let mut vars = Vec::new();
+    for point in points {
+        let var_x: LC = fq_as_scalar(point.0.X).into();
+        let var_y: LC = fq_as_scalar(point.0.Y).into();
+        let var_z: LC = fq_as_scalar(point.0.Z).into();
+        let var_t: LC = fq_as_scalar(point.0.T).into();
+        vars.push((var_x, var_y, var_z, var_t));
+    }
+    vars
+}
+
+/// Commits the coordinates of one public point in the CS
+pub fn commit_point_coords(
+    prover: &mut Prover,
+    point: RistrettoPoint,
+) -> (Vec<CompressedRistretto>, Vec<Variable>) {
+    let mut commitments: Vec<CompressedRistretto> = Vec::new();
+    let mut vars: Vec<Variable> = Vec::new();
+    let com_res = prover.commit(fq_as_scalar(point.0.X), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    let com_res = prover.commit(fq_as_scalar(point.0.Y), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    let com_res = prover.commit(fq_as_scalar(point.0.Z), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    let com_res = prover.commit(fq_as_scalar(point.0.T), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    (commitments, vars)
+}
+
+/// Commits a single variable to the CS
+pub fn commit_single_variable(
+    prover: &mut Prover,
+    var: FieldElement,
+) -> (CompressedRistretto, Variable) {
+    (prover.commit(fq_as_scalar(var), Scalar::random(&mut thread_rng())))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 extern crate bulletproofs;
 mod gadgets;
+mod helpers;
 extern crate zerocaf;


### PR DESCRIPTION
Implements a point addition gadget within Bulletproofs and tests for it.

This is one of the three gadgets needed to implement what is mentioned in https://github.com/dusk-network/dusk-zerocaf/issues/96

Closes #1 