### PR TITLE
Point doubling gadget implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+sudo: true
+os: 
+  - linux
+
+matrix:
+  fast_finish: false
+  include:
+  - rust: nightly
+
+
+before_install:
+  - sudo apt-get update
+
+# Main build
+script:
+  - cargo check
+  - cargo build --verbose --all
+  - cargo test --verbose --all
+
+
+# Send a notification to the Dusk build Status Telegram channel once the CI build completes
+after_script:
+  - bash <(curl -s https://raw.githubusercontent.com/dusk-network/tools/master/bash/telegram_ci_notifications.sh)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,13 @@ edition = "2018"
 
 [dependencies]
 zerocaf = {git = "https://github.com/dusk-network/dusk-zerocaf", branch = "master"}
+merlin = "2.0.0"
+curve25519-dalek = "2.0.0"
 
 [dependencies.bulletproofs]
 git = "https://github.com/dusk-network/bulletproofs"
 branch = "dalek-v2"
 features = ["yoloproofs"]
+
+[dev-dependencies]
+rand = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,9 @@ edition = "2018"
 zerocaf = {git = "https://github.com/dusk-network/dusk-zerocaf", branch = "master"}
 merlin = "2.0.0"
 curve25519-dalek = "2.0.0"
+rand = "0.7.3"
 
 [dependencies.bulletproofs]
 git = "https://github.com/dusk-network/bulletproofs"
 branch = "dalek-v2"
 features = ["yoloproofs"]
-
-[dev-dependencies]
-rand = "0.7.3"

--- a/src/gadgets/mod.rs
+++ b/src/gadgets/mod.rs
@@ -1,2 +1,2 @@
 pub mod point_addition;
-pub mod sk_knowledge;
+pub mod point_doubling;pub mod sk_knowledge;

--- a/src/gadgets/point_addition/add.rs
+++ b/src/gadgets/point_addition/add.rs
@@ -34,8 +34,15 @@ pub fn point_addition_gadget(
         // Try to move this to additions since they are free
         let minus_a = cs.multiply(LC::from(a), LC::from(A)).2;
         let minus_b = cs.multiply(LC::from(a), LC::from(B)).2;
-        minus_a + minus_b + E12;
+        minus_a + minus_b + E12
     };
-    //let F =
-    unimplemented!()
+    let F = D - C;
+    let G = D + C;
+    let H = B + A;
+    (
+        Variable::from(cs.multiply(E.clone(), F.clone()).2),
+        Variable::from(cs.multiply(G.clone(), H.clone()).2),
+        Variable::from(cs.multiply(F, G).2),
+        Variable::from(cs.multiply(E, H).2),
+    )
 }

--- a/src/gadgets/point_addition/add.rs
+++ b/src/gadgets/point_addition/add.rs
@@ -1,9 +1,25 @@
 use bulletproofs::r1cs::{ConstraintSystem, LinearCombination as LC, Variable};
-use zerocaf::edwards::{AffinePoint, EdwardsPoint};
-use zerocaf::field::FieldElement as Fq;
+use curve25519_dalek::scalar::Scalar;
+use zerocaf::field::FieldElement;
 use zerocaf::ristretto::RistrettoPoint;
 
-pub fn point_addition_gadget(
+pub fn fq_as_scalar(elem: FieldElement) -> Scalar {
+    Scalar::from_bytes_mod_order(elem.to_bytes())
+}
+
+pub fn commit_point_coords(
+    cs: &mut ConstraintSystem,
+    point: RistrettoPoint,
+) -> (Variable, Variable, Variable, Variable) {
+    let p_x = cs.allocate(Some(fq_as_scalar(point.0.X))).unwrap();
+    let p_y = cs.allocate(Some(fq_as_scalar(point.0.Y))).unwrap();
+    let p_z = cs.allocate(Some(fq_as_scalar(point.0.Z))).unwrap();
+    let p_t = cs.allocate(Some(fq_as_scalar(point.0.T))).unwrap();
+
+    (p_x, p_y, p_z, p_t)
+}
+
+pub fn add_point_addition_gadget(
     cs: &mut ConstraintSystem,
     (p1_x, p1_y, p1_z, p1_t): (Variable, Variable, Variable, Variable),
     (p2_x, p2_y, p2_z, p2_t): (Variable, Variable, Variable, Variable),
@@ -45,4 +61,52 @@ pub fn point_addition_gadget(
         Variable::from(cs.multiply(F, G).2),
         Variable::from(cs.multiply(E, H).2),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bulletproofs::r1cs::Prover;
+    use bulletproofs::{BulletproofGens, PedersenGens};
+    use merlin::Transcript;
+    use rand::thread_rng;
+    use zerocaf::edwards::{AffinePoint, EdwardsPoint};
+    use zerocaf::field::FieldElement as Fq;
+
+    #[test]
+    fn point_addition_gadget() {
+        let mut rng = thread_rng();
+
+        let gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"Testing");
+
+        let mut prover = Prover::new(&gens, &mut transcript);
+
+        let p1 = RistrettoPoint::new_random_point(&mut rng);
+        let p1_commits = commit_point_coords(&mut prover, p1);
+        let p2 = RistrettoPoint::new_random_point(&mut rng);
+        let p2_commits = commit_point_coords(&mut prover, p2);
+        let p_res = p1 + p2;
+        let a = zerocaf::constants::EDWARDS_A;
+        let a_comm = prover.allocate(Some(fq_as_scalar(a))).unwrap();
+        let d = zerocaf::constants::EDWARDS_D;
+        let d_comm = prover.allocate(Some(fq_as_scalar(d))).unwrap();
+
+        let (X, Y, Z, T) =
+            add_point_addition_gadget(&mut prover, p1_commits, p2_commits, d_comm, a_comm);
+        let (X_real, Y_real, Z_real, T_real) = commit_point_coords(&mut prover, p_res);
+        // As specified on the Ristretto protocol docs:
+        // https://ristretto.group/formulas/equality.html
+        // and we are on the twisted case, we compare
+        // `X1*Y2 == Y1*X2 | X1*X2 == Y1*Y2`.
+        let (_, _, x1_y2) = prover.multiply(LC::from(X), LC::from(Y_real));
+        let (_, _, y1_x2) = prover.multiply(LC::from(Y), LC::from(X_real));
+        let constraint = x1_y2 - y1_x2;
+        prover.constrain(LC::from(constraint));
+        let prove = prover.prove(&BulletproofGens::new(32, 1)).unwrap();
+        let verif = bulletproofs::r1cs::Verifier::new(&mut transcript);
+        assert!(verif
+            .verify(&prove, &gens, &BulletproofGens::new(32, 1), &mut rng)
+            .is_ok())
+    }
 }

--- a/src/gadgets/point_addition/add.rs
+++ b/src/gadgets/point_addition/add.rs
@@ -3,11 +3,10 @@ use bulletproofs::r1cs::{
     ConstraintSystem, LinearCombination as LC, Prover, R1CSError, R1CSProof, Variable, Verifier,
 };
 use bulletproofs::{BulletproofGens, PedersenGens};
-use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use rand::thread_rng;
 use zerocaf::field::FieldElement;
-use zerocaf::ristretto::{CompressedRistretto, RistrettoPoint};
+use zerocaf::ristretto::RistrettoPoint;
 
 /// Builds a proof which holds the constraints related to
 /// the point addition of two publicly known RistrettoPoints.

--- a/src/gadgets/point_doubling/double.rs
+++ b/src/gadgets/point_doubling/double.rs
@@ -156,10 +156,39 @@ fn point_doubling_roundtrip_helper(points: &[RistrettoPoint]) -> Result<(), R1CS
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(32, 1);
 
-    unimplemented!()
+    let proof = point_doubling_proof(
+        &pc_gens,
+        &bp_gens,
+        points[0],
+        points[1],
+        zerocaf::constants::EDWARDS_A,
+        zerocaf::constants::EDWARDS_D,
+    )?;
+
+    point_doubling_verify(
+        &pc_gens,
+        &bp_gens,
+        points[0],
+        points[1],
+        zerocaf::constants::EDWARDS_A,
+        zerocaf::constants::EDWARDS_D,
+        proof,
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zerocaf::traits::ops::Double;
+    #[test]
+    fn point_doubling_prove_verif() {
+        let p1 = RistrettoPoint::new_random_point(&mut thread_rng());
+        let p2 = p1.double();
+        let p3 = p2.double();
+
+        // 2 * P1 = P2
+        assert!(point_doubling_roundtrip_helper(&[p1, p2]).is_ok());
+        // 2 * P1 != P3
+        assert!(point_doubling_roundtrip_helper(&[p1, p3]).is_err());
+    }
 }

--- a/src/gadgets/point_doubling/double.rs
+++ b/src/gadgets/point_doubling/double.rs
@@ -67,7 +67,29 @@ pub fn point_doubling_verify(
     // Create the verifier
     let mut verifier = Verifier::new(&mut transcript);
 
-    unimplemented!()
+    // Commit high-level variables
+    // Get LCs for P1 and 2*P1 => P2
+    let mut lcs = n_point_coords_to_LC(&[p1, p2]);
+    // Get a and d as LC
+    lcs.push((
+        fq_as_scalar(a).into(),
+        fq_as_scalar(d).into(),
+        fq_as_scalar(d).into(),
+        fq_as_scalar(d).into(),
+    ));
+
+    // Build the CS
+    // XXX: We should get the z and t and verify that it satisfies the curve eq
+    // in another gadget.
+    let (x, y, _, _) = point_doubling_gadget(
+        &mut verifier,
+        lcs[0].clone(),
+        lcs[2].1.clone(),
+        lcs[2].0.clone(),
+    );
+    point_doubling_constrain_gadget(&mut verifier, lcs[1].clone(), (x.into(), y.into()));
+
+    verifier.verify(&proof, &pc_gens, &bp_gens, &mut thread_rng())
 }
 
 /// Builds and adds to the CS the circuit that corresponds to the

--- a/src/gadgets/point_doubling/double.rs
+++ b/src/gadgets/point_doubling/double.rs
@@ -1,0 +1,98 @@
+use crate::helpers::{fq_as_scalar, n_point_coords_to_LC};
+use bulletproofs::r1cs::{
+    ConstraintSystem, LinearCombination as LC, Prover, R1CSError, R1CSProof, Variable, Verifier,
+};
+use bulletproofs::{BulletproofGens, PedersenGens};
+use curve25519_dalek::scalar::Scalar;
+use merlin::Transcript;
+use rand::thread_rng;
+use zerocaf::field::FieldElement;
+use zerocaf::ristretto::{CompressedRistretto, RistrettoPoint};
+
+/// Builds a proof which holds the constraints related to
+/// the point doubling of a publicly known RistrettoPoint.
+pub fn point_doubling_proof(
+    pc_gens: &PedersenGens,
+    bp_gens: &BulletproofGens,
+    p1: RistrettoPoint,
+    p2: RistrettoPoint,
+    a: FieldElement,
+    d: FieldElement,
+) -> Result<R1CSProof, R1CSError> {
+    let mut transcript = Transcript::new(b"R1CS Point Add Gadget");
+
+    // Create the prover->
+    let mut prover = Prover::new(pc_gens, &mut transcript);
+
+    // Commit high-level variables
+    // Get LCs for P1, P2 and P1 + P2
+    let mut lcs = n_point_coords_to_LC(&[p1, p2]);
+    // Get a and d as LC
+    lcs.push((
+        fq_as_scalar(a).into(),
+        fq_as_scalar(d).into(),
+        fq_as_scalar(d).into(),
+        fq_as_scalar(d).into(),
+    ));
+
+    // Build the CS
+    // XXX: We should get the z and t and verify that it satisfies the curve eq
+    // in another gadget.
+    unimplemented!()
+}
+
+/// Verifies a proof which holds the constraints related to
+/// the point doubling of a publicly known RistrettoPoint.
+pub fn point_doubling_verify(
+    pc_gens: &PedersenGens,
+    bp_gens: &BulletproofGens,
+    p1: RistrettoPoint,
+    p2: RistrettoPoint,
+    a: FieldElement,
+    d: FieldElement,
+    proof: R1CSProof,
+) -> Result<(), R1CSError> {
+    let mut transcript = Transcript::new(b"R1CS Point Add Gadget");
+
+    // Create the verifier
+    let mut verifier = Verifier::new(&mut transcript);
+
+    unimplemented!()
+}
+
+/// Builds and adds to the CS the circuit that corresponds to the
+/// doubling of a Twisted Edwards point in Extended Coordinates.
+pub fn point_doubling_gadget(
+    cs: &mut ConstraintSystem,
+    (p1_x, p1_y, p1_z, p1_t): (LC, LC, LC, LC),
+    d: LC,
+    a: LC,
+) -> (Variable, Variable, Variable, Variable) {
+    // Point doubling impl
+    // A =
+    unimplemented!()
+}
+
+/// Constrains the logic of the addition between two points of
+/// a twisted edwards elliptic curve in extended coordinates
+/// making sure that P1 + P2 = P3.
+pub fn point_addition_constrain_gadget(
+    cs: &mut ConstraintSystem,
+    p_add: &RistrettoPoint,
+    res_point: &(LC, LC),
+) {
+    unimplemented!()
+}
+
+fn point_addition_roundtrip_helper(points: &[RistrettoPoint]) -> Result<(), R1CSError> {
+    // Common
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(32, 1);
+
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/src/gadgets/point_doubling/double.rs
+++ b/src/gadgets/point_doubling/double.rs
@@ -106,10 +106,22 @@ pub fn point_doubling_gadget(
 /// making sure that P1 + P2 = P3.
 pub fn point_doubling_constrain_gadget(
     cs: &mut ConstraintSystem,
-    p_add: &RistrettoPoint,
+    p_doubled: &RistrettoPoint,
     res_point: &(LC, LC),
 ) {
-    unimplemented!()
+    let res_p_coords = n_point_coords_to_LC(&[*p_doubled]);
+    // As specified on the Ristretto protocol docs:
+    // https://ristretto.group/formulas/equality.html
+    // and we are on the twisted case, we compare
+    // `X1*Y2 == Y1*X2 | X1*X2 == Y1*Y2`.
+    let x1y2 = cs
+        .multiply(res_point.0.clone(), res_p_coords[0].1.clone())
+        .2;
+    let y1x2 = cs
+        .multiply(res_point.1.clone(), res_p_coords[0].0.clone())
+        .2;
+    // Add the constrain
+    cs.constrain((x1y2 - y1x2).into());
 }
 
 fn point_doubling_roundtrip_helper(points: &[RistrettoPoint]) -> Result<(), R1CSError> {

--- a/src/gadgets/point_doubling/double.rs
+++ b/src/gadgets/point_doubling/double.rs
@@ -69,14 +69,42 @@ pub fn point_doubling_gadget(
     a: LC,
 ) -> (Variable, Variable, Variable, Variable) {
     // Point doubling impl
-    // A =
-    unimplemented!()
+    // A = p1_x²
+    // B = p1_y²
+    // C = 2*p1_z²
+    // D = a*A
+    // E = (p1_x + p1_y)² - A - B
+    // G = D + B
+    // F = G - C
+    // H = D - B
+    // X3 = E * F,  Y3 = G * H, Z3 = F * G, T3 = E * H
+    let A = cs.multiply(p1_x.clone(), p1_x.clone()).2;
+    let B = cs.multiply(p1_y.clone(), p1_y.clone()).2;
+    let C = {
+        let p1_z_sq = cs.multiply(p1_z.clone(), p1_z).2;
+        cs.multiply(Scalar::from(2u8).into(), p1_z_sq.into()).2
+    };
+    let D = cs.multiply(a, A.into()).2;
+    let E = {
+        let p1xy_sq = cs.multiply(p1_x.clone() + p1_y.clone(), p1_x + p1_y).2;
+        p1xy_sq - A - B
+    };
+    let G = D + B;
+    let F = G.clone() - C;
+    let H = D - B;
+
+    (
+        cs.multiply(E.clone(), F.clone()).2,
+        cs.multiply(G.clone(), H.clone()).2,
+        cs.multiply(F, G).2,
+        cs.multiply(E, H).2,
+    )
 }
 
-/// Constrains the logic of the addition between two points of
+/// Constrains the logic of the doubling between two points of
 /// a twisted edwards elliptic curve in extended coordinates
 /// making sure that P1 + P2 = P3.
-pub fn point_addition_constrain_gadget(
+pub fn point_doubling_constrain_gadget(
     cs: &mut ConstraintSystem,
     p_add: &RistrettoPoint,
     res_point: &(LC, LC),
@@ -84,7 +112,7 @@ pub fn point_addition_constrain_gadget(
     unimplemented!()
 }
 
-fn point_addition_roundtrip_helper(points: &[RistrettoPoint]) -> Result<(), R1CSError> {
+fn point_doubling_roundtrip_helper(points: &[RistrettoPoint]) -> Result<(), R1CSError> {
     // Common
     let pc_gens = PedersenGens::default();
     let bp_gens = BulletproofGens::new(32, 1);

--- a/src/gadgets/point_doubling/mod.rs
+++ b/src/gadgets/point_doubling/mod.rs
@@ -1,0 +1,1 @@
+mod double;

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,0 +1,77 @@
+use bulletproofs::r1cs::{ConstraintSystem, LinearCombination as LC, Prover, Variable};
+use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::scalar::Scalar;
+use rand::thread_rng;
+use zerocaf::field::FieldElement;
+use zerocaf::ristretto::RistrettoPoint;
+
+pub fn fq_as_scalar(elem: FieldElement) -> Scalar {
+    Scalar::from_bytes_mod_order(elem.to_bytes())
+}
+
+/// Commits the coordinates of the two public points in the CS
+pub fn commit_2_point_coords(
+    prover: &mut Prover,
+    points: (RistrettoPoint, RistrettoPoint),
+) -> (Vec<CompressedRistretto>, Vec<Variable>) {
+    let mut commitments: Vec<CompressedRistretto> = Vec::new();
+    let mut vars: Vec<Variable> = Vec::new();
+    for point in &[points.0, points.1] {
+        let com_res = prover.commit(fq_as_scalar(point.0.X), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+        let com_res = prover.commit(fq_as_scalar(point.0.Y), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+        let com_res = prover.commit(fq_as_scalar(point.0.Z), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+        let com_res = prover.commit(fq_as_scalar(point.0.T), Scalar::random(&mut thread_rng()));
+        commitments.push(com_res.0);
+        vars.push(com_res.1);
+    }
+    (commitments, vars)
+}
+
+/// Converts n points coordinates to variables returning them inside of a vector
+pub fn n_point_coords_to_LC(points: &[RistrettoPoint]) -> Vec<(LC, LC, LC, LC)> {
+    let mut vars = Vec::new();
+    for point in points {
+        let var_x: LC = fq_as_scalar(point.0.X).into();
+        let var_y: LC = fq_as_scalar(point.0.Y).into();
+        let var_z: LC = fq_as_scalar(point.0.Z).into();
+        let var_t: LC = fq_as_scalar(point.0.T).into();
+        vars.push((var_x, var_y, var_z, var_t));
+    }
+    vars
+}
+
+/// Commits the coordinates of one public point in the CS
+pub fn commit_point_coords(
+    prover: &mut Prover,
+    point: RistrettoPoint,
+) -> (Vec<CompressedRistretto>, Vec<Variable>) {
+    let mut commitments: Vec<CompressedRistretto> = Vec::new();
+    let mut vars: Vec<Variable> = Vec::new();
+    let com_res = prover.commit(fq_as_scalar(point.0.X), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    let com_res = prover.commit(fq_as_scalar(point.0.Y), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    let com_res = prover.commit(fq_as_scalar(point.0.Z), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    let com_res = prover.commit(fq_as_scalar(point.0.T), Scalar::random(&mut thread_rng()));
+    commitments.push(com_res.0);
+    vars.push(com_res.1);
+    (commitments, vars)
+}
+
+/// Commits a single variable to the CS
+pub fn commit_single_variable(
+    prover: &mut Prover,
+    var: FieldElement,
+) -> (CompressedRistretto, Variable) {
+    (prover.commit(fq_as_scalar(var), Scalar::random(&mut thread_rng())))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 extern crate bulletproofs;
 mod gadgets;
+mod helpers;
 extern crate zerocaf;


### PR DESCRIPTION
Implements a point doubling gadget within Bulletproofs and tests for it.

This is one of the three gadgets needed to close dusk-network/dusk-zerocaf#96